### PR TITLE
There is new cookie param exists now

### DIFF
--- a/lib/HTTP/Easy.pm
+++ b/lib/HTTP/Easy.pm
@@ -9,7 +9,7 @@ HTTP::Easy - Useful set for work with HTTP
 
 =cut
 
-our $VERSION = '0.03';
+our $VERSION = '0.04';
 
 =head1 SYNOPSIS
 

--- a/lib/HTTP/Easy/Cookies/PP.pm
+++ b/lib/HTTP/Easy/Cookies/PP.pm
@@ -7,7 +7,7 @@ use Scalar::Util 'weaken';
 
 our @MoY = qw(Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec);
 our %MoY;@MoY{@MoY} = (1..12);
-our @Leg = qw(comment commenturl discard domain expires httponly max-age path port secure version );
+our @Leg = qw(comment commenturl discard domain expires httponly max-age path port secure version samesite);
 our %Leg; @Leg{@Leg} = (1)x@Leg;
 
 sub CHECK_PARAM () { 1 }


### PR DESCRIPTION
The SameSite attribute of the Set-Cookie HTTP response header allows you to declare if your cookie should be restricted to a first-party or same-site context.